### PR TITLE
docs: crear y actualizar CHANGELOG.md con contribuciones recientes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+Todas las versiones importantes de **MotorPoint** estarán documentadas en este archivo.
+
+## [Unreleased]
+### Añadido
+- Plantillas de issues para reporte de bugs. (commit `69ee286`)  
+- Archivo de configuración para plantillas de issues. (commit `9e082d8`)  
+- Plantilla para solicitudes de funcionalidad/pull requests mejorada. (commit `df6d189`)  
+- Plantilla para pull requests agregada. (commit `15071b6`)  
+- Archivos de configuración por entorno (dev, local, prod). (commit `0af5681`)  
+- Ruta de archivo sensible añadida al `.gitignore`. (commit `be8b40f`)  
+- Archivo `application.yml` de back-end agregado. (commit `5329ee4`)  
+- Múltiples archivos `.gitkeep` para asegurar la estructura de directorios. (commit `930e1c5`)  
+
+### Modificado
+- Actualización del `README.md` con instrucciones de instalación y flujo Git. (commit `4a84a8c`, `22b8469`)  
+- Corrección en el `README`. (commit `61e551d`)  
+- Flujo de trabajo Git documentado y mejorado. (commit `22b8469`)  
+
+### Eliminado
+- Eliminado componente `Login` y su archivo correspondiente en la “pages” (commit `497bbe4`, `b994e7b`)  
+
+---
+
+## [0.1.0] – 2025-09-18  
+### Añadido
+- Estructura inicial del repositorio: directorios (`components`, `pages`, `services`, `styles`, `context`) con archivos `.gitkeep`. (commits `1378d10`, `6786299`, `d194c9e`, `35c4565`)  
+- Componente `Login` básico creado. (commit `27f95d9`, `35c4565`)  
+- Estructura base para back-end añadida. (commit `a150264`)  
+
+### Modificado
+- Actualización general del `README`. (commit `752adee`)  
+
+---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Todas las versiones importantes de **MotorPoint** estarán documentadas en este 
 - Archivos de configuración por entorno (dev, local, prod). (commit `0af5681`)  
 - Ruta de archivo sensible añadida al `.gitignore`. (commit `be8b40f`)  
 - Archivo `application.yml` de back-end agregado. (commit `5329ee4`)  
-- Múltiples archivos `.gitkeep` para asegurar la estructura de directorios. (commit `930e1c5`)  
+- Múltiples archivos `.gitkeep` para asegurar la estructura de directorios. (commit `930e1c5`)
+- Archivo `CONTRIBUTING.md` agregado. (commit `85aad13`)  
+- Archivo `CHANGELOG.md` agregado. (commit `d58f879`)
 
 ### Modificado
 - Actualización del `README.md` con instrucciones de instalación y flujo Git. (commit `4a84a8c`, `22b8469`)  


### PR DESCRIPTION
### 📝 Descripción
Este PR añade el archivo `CHANGELOG.md` para documentar los cambios significativos en el proyecto MotorPoint. Se incluyen entradas para versiones anteriores y se actualiza con los últimos commits relacionados a plantillas de issues, configuración de entorno, y documentación (`CONTRIBUTING.md`, `README.md`). Esto permite mantener un historial claro y trazable de las versiones y mejoras aplicadas.
