### PR TITLE
docs: agregar archivos CONTRIBUTING.md y CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+Todas las versiones importantes de **MotorPoint** estarán documentadas en este archivo.
+
+## [Unreleased]
+### Añadido
+- Plantillas de issues para reporte de bugs. (commit `69ee286`)  
+- Archivo de configuración para plantillas de issues. (commit `9e082d8`)  
+- Plantilla para solicitudes de funcionalidad/pull requests mejorada. (commit `df6d189`)  
+- Plantilla para pull requests agregada. (commit `15071b6`)  
+- Archivos de configuración por entorno (dev, local, prod). (commit `0af5681`)  
+- Ruta de archivo sensible añadida al `.gitignore`. (commit `be8b40f`)  
+- Archivo `application.yml` de back-end agregado. (commit `5329ee4`)  
+- Múltiples archivos `.gitkeep` para asegurar la estructura de directorios. (commit `930e1c5`)  
+
+### Modificado
+- Actualización del `README.md` con instrucciones de instalación y flujo Git. (commit `4a84a8c`, `22b8469`)  
+- Corrección en el `README`. (commit `61e551d`)  
+- Flujo de trabajo Git documentado y mejorado. (commit `22b8469`)  
+
+### Eliminado
+- Eliminado componente `Login` y su archivo correspondiente en la “pages” (commit `497bbe4`, `b994e7b`)  
+
+---
+
+## [0.1.0] – 2025-09-18  
+### Añadido
+- Estructura inicial del repositorio: directorios (`components`, `pages`, `services`, `styles`, `context`) con archivos `.gitkeep`. (commits `1378d10`, `6786299`, `d194c9e`, `35c4565`)  
+- Componente `Login` básico creado. (commit `27f95d9`, `35c4565`)  
+- Estructura base para back-end añadida. (commit `a150264`)  
+
+### Modificado
+- Actualización general del `README`. (commit `752adee`)  
+
+---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Todas las versiones importantes de **MotorPoint** estarán documentadas en este 
 - Archivos de configuración por entorno (dev, local, prod). (commit `0af5681`)  
 - Ruta de archivo sensible añadida al `.gitignore`. (commit `be8b40f`)  
 - Archivo `application.yml` de back-end agregado. (commit `5329ee4`)  
-- Múltiples archivos `.gitkeep` para asegurar la estructura de directorios. (commit `930e1c5`)  
+- Múltiples archivos `.gitkeep` para asegurar la estructura de directorios. (commit `930e1c5`)
+- Archivo `CONTRIBUTING.md` agregado. (commit `85aad13`)  
+- Archivo `CHANGELOG.md` agregado. (commit `d58f879`)
 
 ### Modificado
 - Actualización del `README.md` con instrucciones de instalación y flujo Git. (commit `4a84a8c`, `22b8469`)  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+
+# Contribuir a MotorPoint
+
+¡Gracias por interesarte en contribuir al proyecto **MotorPoint**!  
+Aquí tienes una guía rápida para hacerlo de forma efectiva y coherente con nuestro flujo de trabajo.
+
+## Guía rápida
+
+1. Haz un **fork** de este repositorio.  
+2. Crea un **branch** en tu fork para tu contribución, siguiendo la convención:  
+   `feature/<descripción-corta>` o `fix/<descripción-corta>`.  
+3. Asegúrate de que tu código pasa las pruebas locales y no genera errores.  
+4. Envía un **Pull Request (PR)** hacia la rama `develop`.  
+5. Rellena el formulario de PR con la plantilla provista (sección de Cambios, Contexto, Capturas si aplica).  
+6. Espera la revisión de al menos otro colaborador. Realiza los cambios necesarios si te lo solicitan.  
+7. Una vez aprobado, tu PR será mergeado y aparecerá en el próximo **CHANGELOG**.  
+
+## Estilo de commits
+
+- Usa la convención:  
+  ```text
+  tipo: descripción breve
+  ```
+
+Donde `tipo` puede ser:
+
+* `feat`: nueva funcionalidad
+* `fix`: corrección de bug
+* `docs`: cambios en la documentación
+* `chore`: tareas auxiliares, infraestructura, limpieza
+* `refactor`: cambios de código que no añaden funcionalidad ni corrigen bugs
+
+Ejemplo:
+
+```text
+feat: add Login component
+fix: actualizar README.md para agregar el flujo de trabajo en git
+docs: agregar plantillas para solicitudes de funcionalidad y tareas generales
+```
+
+## Plantillas de Issues y Pull Requests
+
+Hemos añadido plantillas para reportes de bugs, solicitudes de funcionalidad y PRs con secciones estándar para mantener la consistencia. Por favor, úsalas al crear nuevos issues o PRs.
+
+## Normas de código y pruebas
+
+* Sigue la guía de estilo del proyecto (por ejemplo: indentación, nomenclatura, documentación interna).
+* Incluye pruebas unitarias o de integración cuando aplicable.
+* Asegúrate de que tu cambio no rompe funcionalidades existentes.
+* Actualiza la documentación correspondiente si tu cambio lo requiere.
+
+## Evaluación de Pull Requests
+
+Cuando revises un PR, considera lo siguiente:
+
+* ¿El cambio está correctamente descrito y justificado?
+* ¿Los tests pasan y no se han introducido errores nuevos?
+* ¿Se ha actualizado el `CHANGELOG.md` si es necesario, o tu cambio será documentado en la próxima versión?
+* ¿Se han respetado las convenciones de estilo y commit?
+
+## Gracias
+
+Gracias por ayudar a que MotorPoint sea mejor. ¡Tu aporte hace la diferencia! 🚀
+


### PR DESCRIPTION
### 📝 Descripción del PR
Este PR incorpora dos documentos clave para estandarizar y profesionalizar el flujo de trabajo del equipo:

- Se añade `CONTRIBUTING.md`, que detalla el proceso de contribución, estilo de commits, uso de plantillas y criterios de revisión.
- Se crea `CHANGELOG.md` para documentar los cambios relevantes por versión, facilitando la trazabilidad y comunicación entre colaboradores.

Ambos archivos están alineados con las convenciones de la organización y serán actualizados conforme evolucione el proyecto.