### PR TITLE
Actualización de autenticación en workflows de GitHub Actions para GHCR

### DIFF
--- a/.github/workflows/build-push-ghcr-develop.yml
+++ b/.github/workflows/build-push-ghcr-develop.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.TOKEN_CD }}
 
       - name: Build & push backend (staging)
         uses: docker/build-push-action@v4

--- a/.github/workflows/build-push-ghcr-main.yml
+++ b/.github/workflows/build-push-ghcr-main.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          # Si GITHUB_TOKEN da error, usar un PAT (GHCR_PAT)
+          password: ${{ secrets.TOKEN_CD }}
+          # Si TOKEN_CD da error, usar un PAT (GHCR_PAT)
 
       # ============================
       # BACKEND (Spring Boot)


### PR DESCRIPTION
### 📄 Descripción  
Este pull request modifica el método de autenticación utilizado para publicar imágenes Docker en GitHub Container Registry (GHCR). En lugar de emplear el `GITHUB_TOKEN` por defecto, los workflows ahora utilizan el secreto personalizado `TOKEN_CD`, lo que mejora la gestión de credenciales y la seguridad.  

Los cambios aplican tanto al workflow de la rama **develop** como al de la rama **main**, incluyendo la actualización de comentarios para reflejar el nuevo token de respaldo.  